### PR TITLE
Passe en ESNext

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "commonjs",
         "esModuleInterop": true,
         "allowSyntheticDefaultImports": true,
-        "target": "es6",
+        "target": "ESNext",
         "noImplicitAny": true,
         "moduleResolution": "node",
         "sourceMap": true,


### PR DESCRIPTION
… pour autoriser `.replaceAll()`. On aurait pu se contenter de ES2021, mais pas de restrictions à aller sur ESNext directement.